### PR TITLE
商品消去機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
 
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -35,6 +35,11 @@ class ItemsController < ApplicationController
       Rails.logger.info @item.errors.full_messages
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item),data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", item_buyers_path(@item) , data: { turbo: false }, class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   
   root to: 'items#index'
   resources :users
-  resources :items, only: [:index, :new, :create, :show, :edit, :update ] do
+  resources :items do
     resources :buyers, only: [:index, :create]
   end
 end


### PR DESCRIPTION
# What

商品詳細ページからの削除オプションの提供

# Why（なぜこの機能が必要なのか）

ユーザーの管理能力の向上：ユーザーが自分の出品した商品を管理し、必要に応じて削除する能力を持つことは、ユーザーエクスペリエンスを向上させます。

データの正確性：誤って出品された商品や、もはや利用価値のない商品を削除することで、プラットフォーム上のデータの正確性と関連性を維持します。

#　動作確認

https://gyazo.com/03e07266e3145898c8aaac3db20dd4b0